### PR TITLE
extend mock functionality to response to a request base on the specified method

### DIFF
--- a/src/net/logicaltrust/context/MockContextMenuFactory.java
+++ b/src/net/logicaltrust/context/MockContextMenuFactory.java
@@ -76,7 +76,7 @@ public class MockContextMenuFactory implements IContextMenuFactory {
                 if (addOption == AddMockOption.SITEMAP) {
                     processSitemap(analyzedURL);
                 } else {
-                    addMock(addOption.isFullUrl(), msg, analyzedURL);
+                    addMock(addOption.isFullUrl(), msg, analyzedURL, getAnalyzedMethod(msg));
                 }
             }
         } catch (Exception ex) {
@@ -95,7 +95,7 @@ public class MockContextMenuFactory implements IContextMenuFactory {
                 continue;
             }
             URL analyzedURL = getAnalyzedURL(msg);
-            addMock(AddMockOption.SITEMAP.isFullUrl(), msg, analyzedURL);
+            addMock(AddMockOption.SITEMAP.isFullUrl(), msg, analyzedURL, getAnalyzedMethod(msg));
         }
     }
 
@@ -104,12 +104,21 @@ public class MockContextMenuFactory implements IContextMenuFactory {
         return analyzedReq.getUrl();
     }
 
-    private void addMock(boolean fullURL, IHttpRequestResponse msg, URL analyzedURL) {
+    private String getAnalyzedMethod(IHttpRequestResponse msg) {
+        IRequestInfo analyzedReq = helpers.analyzeRequest(msg.getHttpService(), msg.getRequest());
+        String method = analyzedReq.getMethod();
+        if (method.isEmpty()) {
+            method = "Any";
+        }
+        return method;
+    }
+
+    private void addMock(boolean fullURL, IHttpRequestResponse msg, URL analyzedURL, String method) {
         MockRule mockRule;
         if (fullURL) {
-            mockRule = MockRule.fromURL(analyzedURL);
+            mockRule = MockRule.fromURL(analyzedURL, method);
         } else {
-            mockRule = MockRule.fromURLwithoutQuery(analyzedURL);
+            mockRule = MockRule.fromURLwithoutQuery(analyzedURL, method);
         }
         MockEntry mockEntry = new MockEntry(true, mockRule, msg.getResponse());
         mockAdder.addMock(mockEntry);

--- a/src/net/logicaltrust/model/MockEntry.java
+++ b/src/net/logicaltrust/model/MockEntry.java
@@ -82,7 +82,7 @@ public class MockEntry {
     }
 
     public Object[] toObject() {
-        return new Object[]{enabled, getRule().getProtocol(), getRule().getHost(), getRule().getPort(), getRule().getPath()};
+        return new Object[]{enabled, getRule().getProtocol(), getRule().getHttpMethod(),  getRule().getHost(), getRule().getPort(), getRule().getPath()};
     }
 
     @Override

--- a/src/net/logicaltrust/model/MockHttpMethodEnum.java
+++ b/src/net/logicaltrust/model/MockHttpMethodEnum.java
@@ -1,0 +1,77 @@
+package net.logicaltrust.model;
+
+public enum MockHttpMethodEnum {
+
+    ANY("Any") {
+        public boolean matches(String method) {
+            return true;
+        }
+    },
+
+    GET("GET") {
+        public boolean matches(String method) {
+            return "get".equalsIgnoreCase(method);
+        }
+    },
+
+    HEAD("HEAD") {
+        public boolean matches(String method) {
+            return "head".equalsIgnoreCase(method);
+        }
+    },
+    
+    POST("POST") {
+        public boolean matches(String method) {
+            return "post".equalsIgnoreCase(method);
+        }
+    },
+
+    PUT("PUT") {
+        public boolean matches(String method) {
+            return "put".equalsIgnoreCase(method);
+        }
+    },
+    
+    DELETE("DELETE") {
+        public boolean matches(String method) {
+            return "delete".equalsIgnoreCase(method);
+        }
+    },
+
+    CONNECT("CONNECT") {
+        public boolean matches(String method) {
+            return "connect".equalsIgnoreCase(method);
+        }
+    },
+    
+    OPTIONS("OPTIONS") {
+        public boolean matches(String method) {
+            return "options".equalsIgnoreCase(method);
+        }
+    },
+
+    TRACE("TRACE") {
+        public boolean matches(String method) {
+            return "trace".equalsIgnoreCase(method);
+        }
+    },
+
+    PATCH("PATCH") {
+        public boolean matches(String method) {
+            return "patch".equalsIgnoreCase(method);
+        }
+    };
+
+    private final String httpMethod;
+
+    MockHttpMethodEnum(String method) {
+        this.httpMethod = method;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public abstract boolean matches(String method);
+
+}

--- a/src/net/logicaltrust/model/MockRule.java
+++ b/src/net/logicaltrust/model/MockRule.java
@@ -11,6 +11,8 @@ public class MockRule {
     @Expose
     private MockProtocolEnum protocol;
     @Expose
+    private MockHttpMethodEnum httpMethod;
+    @Expose
     private String host;
     @Expose
     private String port;
@@ -20,26 +22,29 @@ public class MockRule {
     private Pattern portRegex;
     private Pattern hostRegex;
 
-    public MockRule(MockProtocolEnum protocol, String host, String port, String path) {
+    public MockRule(MockProtocolEnum protocol, MockHttpMethodEnum httpMethod, String host, String port, String path) {
         this.setHost(host);
         this.setPath(path);
         this.setPort(port);
         this.protocol = protocol;
+        this.httpMethod = httpMethod;
     }
 
     public MockRule() {
 
     }
 
-    public static MockRule fromURLwithoutQuery(URL url) {
+    public static MockRule fromURLwithoutQuery(URL url, String method) {
         return new MockRule(MockProtocolEnum.fromURL(url),
+                MockHttpMethodEnum.valueOf(method),
                 decorateFull(url.getHost()),
                 decorateFull(getPortFromURL(url)),
                 decorateFromStart(url.getPath()));
     }
 
-    public static MockRule fromURL(URL url) {
+    public static MockRule fromURL(URL url, String method) {
         return new MockRule(MockProtocolEnum.fromURL(url),
+                MockHttpMethodEnum.valueOf(method),
                 decorateFull(url.getHost()),
                 decorateFull(getPortFromURL(url)),
                 decorateFull(url.getFile()));
@@ -109,13 +114,22 @@ public class MockRule {
         this.protocol = protocol;
     }
 
+    public MockHttpMethodEnum getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(MockHttpMethodEnum method) {
+        this.httpMethod = method;
+    }
+
     @Override
     public String toString() {
-        return "MockRule [protocol=" + protocol + ", host=" + host + ", port=" + port + ", path=" + path + "]";
+        return "MockRule [protocol=" + protocol + ", method=" + httpMethod + ", host=" + host + ", port=" + port +
+                ", path=" + path + "]";
     }
 
     public MockRule duplicate() {
-        return new MockRule(this.protocol, this.host, this.port, this.path);
+        return new MockRule(this.protocol, this.httpMethod, this.host, this.port, this.path);
     }
 
 }

--- a/src/net/logicaltrust/persistent/MockJsonSerializer.java
+++ b/src/net/logicaltrust/persistent/MockJsonSerializer.java
@@ -6,6 +6,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import net.logicaltrust.SimpleLogger;
 import net.logicaltrust.model.MockEntry;
+import net.logicaltrust.model.MockHttpMethodEnum;
 import net.logicaltrust.model.MockProtocolEnum;
 import net.logicaltrust.model.MockRule;
 
@@ -74,6 +75,7 @@ public class MockJsonSerializer {
             jsonWriter.name("path").value(mockRule.getPath());
             jsonWriter.name("port").value(mockRule.getPort());
             jsonWriter.name("protocol").value(mockRule.getProtocol().name());
+            jsonWriter.name("method").value(mockRule.getHttpMethod().name());
             jsonWriter.endObject();
         }
 
@@ -97,6 +99,10 @@ public class MockJsonSerializer {
 
                     case "protocol":
                         rule.setProtocol(MockProtocolEnum.valueOf(jsonReader.nextString()));
+                        break;
+
+                    case "method":
+                        rule.setHttpMethod(MockHttpMethodEnum.valueOf(jsonReader.nextString()));
                         break;
                 }
             }

--- a/src/net/logicaltrust/tab/MockRuleColumnsEnum.java
+++ b/src/net/logicaltrust/tab/MockRuleColumnsEnum.java
@@ -10,6 +10,8 @@ public enum MockRuleColumnsEnum {
 
     PROTOCOL("Protocol"),
 
+    METHOD("Method"),
+
     HOST("Host"),
 
     PORT("Port"),

--- a/src/net/logicaltrust/tab/MockTable.java
+++ b/src/net/logicaltrust/tab/MockTable.java
@@ -3,6 +3,7 @@ package net.logicaltrust.tab;
 import net.logicaltrust.SimpleLogger;
 import net.logicaltrust.editor.MockRuleEditor;
 import net.logicaltrust.model.MockEntry;
+import net.logicaltrust.model.MockHttpMethodEnum;
 import net.logicaltrust.model.MockProtocolEnum;
 import net.logicaltrust.model.MockRule;
 import net.logicaltrust.persistent.MockJsonSerializer;
@@ -236,15 +237,23 @@ class MockTable extends JPanel {
         table.getColumnModel().getColumn(1).setCellEditor(new DefaultCellEditor(protoCombo));
     }
 
+    private void prepareHttpMethodEnumCombo(JTable table) {
+        JComboBox<MockHttpMethodEnum> httpMethodCombo = new JComboBox<>(MockHttpMethodEnum.values());
+        table.getColumnModel().getColumn(2).setCellEditor(new DefaultCellEditor(httpMethodCombo));
+    }
+
     private void handleAdd() {
         JComboBox<MockProtocolEnum> proto = new JComboBox<>(MockProtocolEnum.values());
+        JComboBox<MockHttpMethodEnum> method = new JComboBox<>(MockHttpMethodEnum.values());
         JTextField host = new JTextField();
         JTextField port = new JTextField();
         JTextField file = new JTextField();
-        Object[] msg = new Object[]{"Protocol", proto, "Host", host, "Port", port, "File", file};
+        Object[] msg = new Object[]{"Protocol", proto, "Method", method, "Host", host, "Port", port, "File", file};
         int result = JOptionPane.showConfirmDialog(this, msg, "Add mock", JOptionPane.OK_CANCEL_OPTION);
         if (result == JOptionPane.OK_OPTION) {
-            MockRule rule = new MockRule((MockProtocolEnum) proto.getSelectedItem(), host.getText(), port.getText(), file.getText());
+            MockRule rule = new MockRule((MockProtocolEnum) proto.getSelectedItem(),
+                    (MockHttpMethodEnum) method.getSelectedItem(),
+                    host.getText(), port.getText(), file.getText());
             addRule(rule);
         }
     }
@@ -264,7 +273,7 @@ class MockTable extends JPanel {
             String clipboard = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
             try {
                 URL url = new URL(clipboard);
-                MockRule rule = MockRule.fromURL(url);
+                MockRule rule = MockRule.fromURL(url, "Any");
                 addRule(rule);
             } catch (MalformedURLException e2) {
                 logger.debug("Cannot parse URL " + clipboard);
@@ -292,11 +301,14 @@ class MockTable extends JPanel {
         table.getColumnModel().getColumn(0).setMaxWidth(65);
         table.getColumnModel().getColumn(1).setMaxWidth(75);
         table.getColumnModel().getColumn(1).setPreferredWidth(70);
-        table.getColumnModel().getColumn(2).setPreferredWidth(150);
-        table.getColumnModel().getColumn(3).setMaxWidth(70);
-        table.getColumnModel().getColumn(3).setPreferredWidth(70);
-        table.getColumnModel().getColumn(4).setPreferredWidth(300);
+        table.getColumnModel().getColumn(2).setPreferredWidth(90);
+        table.getColumnModel().getColumn(2).setMaxWidth(90);
+        table.getColumnModel().getColumn(3).setPreferredWidth(150);
+        table.getColumnModel().getColumn(4).setMaxWidth(70);
+        table.getColumnModel().getColumn(4).setPreferredWidth(70);
+        table.getColumnModel().getColumn(5).setPreferredWidth(300);
         prepareProtocolEnumCombo(table);
+        prepareHttpMethodEnumCombo(table);
         JScrollPane scroll = new JScrollPane(table);
         scroll.setVisible(true);
         this.add(scroll, BorderLayout.CENTER);

--- a/src/net/logicaltrust/tab/MockTableModel.java
+++ b/src/net/logicaltrust/tab/MockTableModel.java
@@ -2,6 +2,7 @@ package net.logicaltrust.tab;
 
 import net.logicaltrust.SimpleLogger;
 import net.logicaltrust.model.MockEntry;
+import net.logicaltrust.model.MockHttpMethodEnum;
 import net.logicaltrust.model.MockProtocolEnum;
 import net.logicaltrust.persistent.MockRepository;
 
@@ -67,6 +68,9 @@ class MockTableModel extends DefaultTableModel {
                 break;
             case PROTOCOL:
                 mockHolder.update(row, e -> e.getRule().setProtocol((MockProtocolEnum) value));
+                break;
+            case METHOD:
+                mockHolder.update(row, e -> e.getRule().setHttpMethod((MockHttpMethodEnum) value));
                 break;
             default:
                 break;

--- a/test_data/test_json.json
+++ b/test_data/test_json.json
@@ -5,7 +5,8 @@
       "host": "^www\\.google\\.com$",
       "path": "^/$",
       "port": "^443$",
-      "protocol": "HTTPS"
+      "protocol": "HTTPS",
+      "method": "Any"
     },
     "entryInput": "SFRUUC8xLjEgMjAwIE9LDQoNClRlc3Q\u003d",
     "entryType": "DirectEntry"


### PR DESCRIPTION
There was a need to mock http response for Angular apps but only for the specific method(s). When dealing with CORS Angular app always initiate a http request check using http method of OPTIONS and only if everything is okay it will then make a second call using the appropriate method (GET, POST etc...). With the current implementation Angular app always get the matched mocked response regardless of the http request method.

This newly added functionality it will resolve the mentioned problem and hopefully someone else out there also finding this useful to them too.